### PR TITLE
Added option for defining `timeToLiveSpecification` as part of table …

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ inputs:
           KeyType: HASH
       Projection:
         ProjectionType: 'ALL'
+  timeToLiveSpecification:       # (optional) 
+    AttributeName: attribute2
+    Enabled: false
   region: us-east-1
 ```
 

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -5,7 +5,7 @@ const { mergeDeepRight, pick } = require('ramda');
 const AWS = require('aws-sdk');
 // eslint-disable-next-line import/no-unresolved
 const { Component } = require('@serverless/core');
-const { log, createTable, deleteTable, describeTable, updateTable } = require('./utils');
+const { log, createTable, deleteTable, describeTable, updateTable, updateTimeToLive } = require('./utils');
 
 const outputsList = ['name', 'arn', 'region'];
 
@@ -27,6 +27,7 @@ const defaults = {
   name: null,
   region: 'us-east-1',
   deletionPolicy: 'delete',
+  timeToLiveSpecification: undefined
 };
 
 class AwsDynamoDb extends Component {
@@ -86,6 +87,11 @@ class AwsDynamoDb extends Component {
 
       const prevGlobalSecondaryIndexes = prevTable.globalSecondaryIndexes || [];
       await updateTable.call(this, { dynamodb, prevGlobalSecondaryIndexes, ...config });
+    }
+
+    if (config.timeToLiveSpecification) {
+      await updateTimeToLive({dynamodb, ...config})
+
     }
 
     log(`Table ${config.name} was successfully deployed to the ${config.region} region.`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,10 +119,25 @@ async function deleteTable({ dynamodb, name }) {
   return !!res;
 }
 
+async function updateTimeToLive({dynamodb, name, timeToLiveSpecification= {}}) {
+  return await dynamodb.waitFor('tableExists', { TableName: name}, async function(err, data) {
+    if (err) throw err;
+    return await dynamodb
+      .updateTimeToLive({
+        TableName: name,
+        TimeToLiveSpecification: {
+          AttributeName: timeToLiveSpecification.AttributeName,
+          Enabled: timeToLiveSpecification.Enabled,
+        }
+      }).promise();
+  }).promise();
+}
+
 module.exports = {
   log,
   createTable,
   describeTable,
   updateTable,
   deleteTable,
+  updateTimeToLive,
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { sleep, generateId, getCredentials, getServerlessSdk, getTable } = require('./utils');
+const { sleep, generateId, getCredentials, getServerlessSdk, getTable, getTableTimeToLive } = require('./utils');
 
 // set enough timeout for deployment to finish
 jest.setTimeout(30000);
@@ -16,6 +16,10 @@ const instanceYaml = {
   stage: 'dev',
   inputs: {
     deletionPolicy: 'delete',
+    timeToLiveSpecification: {
+      AttributeName : 'expires',
+      Enabled: true
+    },
     attributeDefinitions: [
       {
         AttributeName: 'attribute1',
@@ -74,6 +78,8 @@ it('should successfully deploy dynamodb table and local index', async () => {
   await sleep(5000);
 
   const res = await getTable(credentials, name);
+
+  //const resTTL = await getTableTimeToLive(credentials, name);
 
   expect(instance.outputs.name).toBeDefined();
   expect(instance.outputs.arn).toBeDefined();

--- a/test/utils.js
+++ b/test/utils.js
@@ -28,7 +28,7 @@ const getCredentials = () => {
   };
 
   if (!credentials.aws.accessKeyId || !credentials.aws.accessKeyId) {
-    throw new Error('Unable to run tests. AWS credentials not found in the envionrment');
+    throw new Error('Unable to run tests. AWS credentials not found in the environment');
   }
 
   return credentials;
@@ -67,4 +67,23 @@ const getTable = async (credentials, tableName) => {
     .promise();
 };
 
-module.exports = { sleep, generateId, getCredentials, getServerlessSdk, getTable };
+/*
+ * Fetches a DynamoDB timeToLive for a table from aws for validation
+ * @param ${object} credentials - the cross provider credentials object
+ * @param ${string} tableName - the name of the dynamodb table
+ */
+const getTableTimeToLive = async (credentials, tableName) => {
+  const config = {
+    credentials: credentials.aws,
+    region: 'us-east-1',
+  };
+  const dynamodb = new AWS.DynamoDB(config);
+
+  return dynamodb
+    .describeTimeToLive({
+      TableName: tableName,
+    })
+    .promise();
+};
+
+module.exports = { sleep, generateId, getCredentials, getServerlessSdk, getTable, getTableTimeToLive };


### PR DESCRIPTION
…definition


I was unfortunately unable to get any of the tests to work locally, but added a commented line to existing test to allow retrieval and checking of the TTL status.

I just kept getting the following error on tests, despite the app-name being valid. 
```
Error: 500 - app-name may contain only numbers, uppercase letters, lowercase letters, dashes, and underscores.
      at Object.request (node_modules/@serverless/platform-client/src/utils.js:43:13)
```

